### PR TITLE
Handle member identifiers, isValidIdentifier checks

### DIFF
--- a/fixtures/identifiers.test.js
+++ b/fixtures/identifiers.test.js
@@ -1,0 +1,8 @@
+// @expected b ḃ ë a await
+// @ts-nocheck
+exports['b'] = 1;
+exports['ḃ'] = 2;
+exports['ë'] = 3;
+exports.\u0061 = 10;
+module.exports['♯'] = 4;
+exports['await'] = 20;

--- a/fixtures/simple-module-exports-property-assignment.test.js
+++ b/fixtures/simple-module-exports-property-assignment.test.js
@@ -1,7 +1,7 @@
 // @expected a b c d e f g h i j k l m n o p q r s t u v w x y z
 // @ts-nocheck
 module.exports.a = 1;
-label: module.exports.b = 2;
+label: module.exports['b'] = 2;
 throw module.exports.c = 3;
 ;(
   module.exports.d = 4


### PR DESCRIPTION
We should probably support `exports['blah'] = value` as well.

I've also added `isValidIdentifier` to all the literal values. I've done this only for literal values to avoid any possible perf cost of running it against already-known identifiers unnecessarily.