### PR TITLE
Disable __esModule interop handling

### DIFF
--- a/fixtures/esmodule-interop-true.test.js
+++ b/fixtures/esmodule-interop-true.test.js
@@ -1,3 +1,3 @@
-// @expected __esModule default
+// @expected __esModule
 exports.__esModule = true;
 exports.default = 'default';

--- a/index.js
+++ b/index.js
@@ -827,20 +827,7 @@ function performAnalysis(filename, job) {
   if (rootState.scopes.scopes.length !== 0) {
     throw new Error('malformed scope chain');
   }
-  const interopAssignments = staticAssignmentNames.get('__esModule');
-  let isActingAsESM = Boolean(interopAssignments);
-  if (interopAssignments) {
-    if (staticAssignmentNames.has('default')) {
-      if (interopAssignments.some(({computed, value}) => {
-        return computed || Boolean(value) !== true
-      })) {
-        isActingAsESM = false;
-      }
-    }
-  }
-  if (isActingAsESM !== true) {
-    staticAssignmentNames.delete('default');
-  }
+  staticAssignmentNames.delete('default');
   job.resolve(staticAssignmentNames.keys(), exportsAllFrom);
 }
 module.exports = Analyzer;


### PR DESCRIPTION
I don't think we should be making allowance for `exports.default` under `__esModule` interop at the cost of breaking the critical invariant that:

`import cjs from 'cjs'` will always correspond to the module instance in the CJS loader.

I do think this invariant is absolutely necessary to maintain in all cases.